### PR TITLE
Remove invisible marker that's blocking hover styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## CHANGE LOG
 - All notable changes to this project will be documented here.
 
+## [1.3.2] - 2019-02-05
+- Remove invisible marker that's blocking hover styles
+- https://github.com/AckerApple/agm-overlays/pull/25
+
 ## [1.3.1] - 2018-10-25
 - Fix updating marker positions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agm-overlays",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Custom marker overlay for the @agm/core package",
   "main": "dist/index",
   "scripts": {

--- a/src/AgmOverlay.component.ts
+++ b/src/AgmOverlay.component.ts
@@ -160,6 +160,7 @@ export interface latLngPlus{
       this.overlayView.iconUrl = " "
       this.overlayView.latitude = this.latitude
       this.overlayView.longitude = this.longitude
+      this.overlayView.visible = false;
     /* end */
 
     if( this.bounds ){

--- a/src/AgmOverlay.component.ts
+++ b/src/AgmOverlay.component.ts
@@ -160,7 +160,7 @@ export interface latLngPlus{
       this.overlayView.iconUrl = " "
       this.overlayView.latitude = this.latitude
       this.overlayView.longitude = this.longitude
-      this.overlayView.visible = false;
+      this.overlayView.visible = false//hide 40x40 transparent placeholder that prevents hover events
     /* end */
 
     if( this.bounds ){


### PR DESCRIPTION
As per the closed issue #24 here's a PR describing exactly the change I need. As you can see from the screenshot, the AGM marker that's created causes a 40px transparent image to be inserted in the DOM at a higher z-index than my custom overlay so my custom overlay can no longer receive hover events. This PR just sets the visibility of that dummy AGM marker to false so it won't render the unnecessary transparent image.

![image](https://user-images.githubusercontent.com/674115/52241367-51875e00-2888-11e9-9adb-dac034350dfe.png)
